### PR TITLE
docs: add link to nRF Asset Tracker for Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![ESLint: TypeScript](https://img.shields.io/badge/ESLint-TypeScript-blue.svg)](https://github.com/typescript-eslint/typescript-eslint)
 
 Simulates an nRF9160-based device for the
-[nRF Asset Tracker for Azure](https://github.com/NordicSemiconductor/asset-tracker-cloud-device-simulator-azure-js).
+[nRF Asset Tracker for Azure](https://github.com/NordicSemiconductor/asset-tracker-cloud-azure-js).
 
 ## Standalone usage
 


### PR DESCRIPTION
Update README. 

Before the link related to text "nRF Asset Tracker for Azure" was this repo's link, but is should be the link of `nRF Asset Tracker for Azure`'s repo, as it is right now. 

Issue description: #123 